### PR TITLE
Roll back pydantic generators to 1.4.3

### DIFF
--- a/fern/fern.config.json
+++ b/fern/fern.config.json
@@ -1,4 +1,4 @@
 {
   "organization": "method-security",
-  "version": "0.41.0"
+  "version": "0.41.8"
 }

--- a/fern/generators.yml
+++ b/fern/generators.yml
@@ -12,14 +12,14 @@ groups:
   pypi-local:
     generators:
       - name: fernapi/fern-pydantic-model
-        version: 1.4.4
+        version: 1.4.3
         output:
           location: local-file-system
           path: ../generated/python
   pypi-test:
     generators:
       - name: fernapi/fern-pydantic-model
-        version:  1.4.4
+        version:  1.4.3
         config:
           package_name: methodokta
         output:
@@ -30,7 +30,7 @@ groups:
   pypi:
     generators:
       - name: fernapi/fern-pydantic-model
-        version: 1.4.4
+        version: 1.4.3
         config:
           package_name: methodokta
         output:


### PR DESCRIPTION
* Rolling back generators due to Fern pydantic field alias change